### PR TITLE
Updated readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ and its password is confluex.
 
 MockHttpsServer server = new MockHttpsServer(443)
 
+```
 # License
 
    Copyright 2013 Confluex, Inc.


### PR DESCRIPTION
A groovy section wasn't closed out properly and the License was shown weird.
